### PR TITLE
Use golang:X.Y.Z-nanoserver for Windows image

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -1,6 +1,7 @@
 # escape = `
 ARG WINDOWS_RELEASE=1809
-FROM golang:1.21.3-nanoserver-$WINDOWS_RELEASE AS build
+
+FROM golang:1.21.3-nanoserver AS build
 WORKDIR \Source
 COPY go.mod go.sum \Source\
 RUN go mod download


### PR DESCRIPTION
This way it should be possible for Dependabot to update golang image.