### PR TITLE
Show OS in job name in Build workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           tags: |
             ghcr.io/chitoku-k/cloudflare-exporter:latest
   build-windows:
-    name: Build (Windows)
+    name: Build (${{ matrix.target.os }})
     strategy:
       matrix:
         target:


### PR DESCRIPTION
This PR updates Build workflow to include target architecture.